### PR TITLE
Repositories/User

### DIFF
--- a/src/main/java/wolox/training/repositories/UserRepository.java
+++ b/src/main/java/wolox/training/repositories/UserRepository.java
@@ -1,0 +1,22 @@
+package wolox.training.repositories;
+
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import wolox.training.models.User;
+
+/**
+ * A repository for {@link User}s.
+ */
+@Repository
+public interface UserRepository extends CrudRepository<User, Long> {
+
+    /**
+     * Returns one {@link User} with the given {@code username}
+     *
+     * @param username The username used to search for a {@link User}.
+     * @return An {@link Optional} containing a {@link User} with the given {@code username} if
+     * there is such, or empty otherwise.
+     */
+    Optional<User> getByUsername(final String username);
+}


### PR DESCRIPTION
# Summary

This PR adds the ```UserRepository```, according to the trello card: [https://trello.com/c/7iDa1iIR](https://trello.com/c/7iDa1iIR)

# Notes

- The ```getByUsername``` returns an ```Optional``` which will contain a ```User``` with the given ```username``` if it exists, or will be empty in case there is no book by the said author.

The base branch is models/book, which should be changed to dev once [the models/user PR](https://github.com/wolox-training/jmb-java/pull/6) is merged.

# Trello Card

https://trello.com/c/7iDa1iIR


