### PR TITLE
bug/search-non-unique

### DIFF
--- a/src/main/java/wolox/training/repositories/BookRepository.java
+++ b/src/main/java/wolox/training/repositories/BookRepository.java
@@ -18,5 +18,5 @@ public interface BookRepository extends CrudRepository<Book, Long> {
      * @return An {@link Optional} containing a {@link Book} of the given {@code author} if there is
      * such, or empty otherwise.
      */
-    Optional<Book> getByAuthor(final String author);
+    Optional<Book> getFirstByAuthor(final String author);
 }

--- a/src/main/java/wolox/training/repositories/UserRepository.java
+++ b/src/main/java/wolox/training/repositories/UserRepository.java
@@ -18,5 +18,5 @@ public interface UserRepository extends CrudRepository<User, Long> {
      * @return An {@link Optional} containing a {@link User} with the given {@code username} if
      * there is such, or empty otherwise.
      */
-    Optional<User> getByUsername(final String username);
+    Optional<User> getFirstByUsername(final String username);
 }

--- a/src/test/java/wolox/training/repositories/BookRepositoryTest.java
+++ b/src/test/java/wolox/training/repositories/BookRepositoryTest.java
@@ -85,15 +85,35 @@ class BookRepositoryTest {
     }
 
     /**
-     * Tests that retrieving an existing {@link Book} with the {@link BookRepository#getByAuthor(String)}
+     * Tests that retrieving an existing {@link Book} with the {@link BookRepository#getFirstByAuthor(String)}
      * performs as expected: Returns a non empty {@link java.util.Optional} containing the existing
      * {@link Book} (i.e with the same values).
      */
     @Test
     @DisplayName("Retrieve Book by author")
     void testRetrieveByAuthor() {
-        retrieveTesting(BookRepository::getByAuthor, Book::getAuthor);
+        retrieveTesting(BookRepository::getFirstByAuthor, Book::getAuthor);
     }
+
+    /**
+     * Tests that searching by author does not throw any exception when the database has more than
+     * one {@link Book} with the same author.
+     */
+    @Test
+    @DisplayName("Retrieve Book by author - More than one Book with the same author in the database")
+    void testSeveralBooksWithSameAuthor() {
+        RepositoriesTestHelper.testSeveralInstancesAndJustOneSearch(
+            bookRepository,
+            BookRepository::getFirstByAuthor,
+            Book::getAuthor,
+            entityManager,
+            TestHelper::mockBook,
+            BookRepositoryTest::cloneBook,
+            "An unexpected exception was thrown when retrieving a Book by author"
+                + " when there is more than one Book with the same author in the database"
+        );
+    }
+
 
     /**
      * Abstract test for retrieving operations.
@@ -115,6 +135,26 @@ class BookRepositoryTest {
             entityManager,
             TestHelper::mockBookList,
             BookAssertions::assertSame
+        );
+    }
+
+    /**
+     * Clones the given {@link Book} (i.e creates a new {@link Book} instance using the same values
+     * as the given).
+     *
+     * @return A new instance of the {@link Book}.
+     */
+    private static Book cloneBook(final Book book) {
+        return new Book(
+            book.getGenre(),
+            book.getAuthor(),
+            book.getImage(),
+            book.getTitle(),
+            book.getSubtitle(),
+            book.getPublisher(),
+            book.getYear(),
+            book.getPages(),
+            book.getIsbn()
         );
     }
 }

--- a/src/test/java/wolox/training/repositories/UserRepositoryTest.java
+++ b/src/test/java/wolox/training/repositories/UserRepositoryTest.java
@@ -97,14 +97,33 @@ class UserRepositoryTest {
     }
 
     /**
-     * Tests that retrieving an existing {@link User} with the {@link UserRepository#getByUsername(String)}
+     * Tests that retrieving an existing {@link User} with the {@link UserRepository#getFirstByUsername(String)}
      * performs as expected: Returns a non empty {@link Optional} containing the existing {@link
      * User} (i.e with the same values).
      */
     @Test
     @DisplayName("Retrieve User by username")
     void testRetrieveByUsername() {
-        retrieveTesting(UserRepository::getByUsername, User::getUsername);
+        retrieveTesting(UserRepository::getFirstByUsername, User::getUsername);
+    }
+
+    /**
+     * Tests that searching by username does not throw any exception when the database has more than
+     * one {@link User} with the same username.
+     */
+    @Test
+    @DisplayName("Retrieve User by username - More than one User with same username in the database")
+    void testSeveralUsersWithSameUsername() {
+        RepositoriesTestHelper.testSeveralInstancesAndJustOneSearch(
+            userRepository,
+            UserRepository::getFirstByUsername,
+            User::getUsername,
+            entityManager,
+            TestHelper::mockUser,
+            UserRepositoryTest::cloneUser,
+            "An unexpected exception was thrown when retrieving a User by username"
+                + " when there is more than one User with the same username in the database"
+        );
     }
 
     /**
@@ -138,7 +157,7 @@ class UserRepositoryTest {
         @Autowired final PlatformTransactionManager platformTransactionManager) {
         testLazyInitialization(
             platformTransactionManager,
-            UserRepository::getByUsername,
+            UserRepository::getFirstByUsername,
             User::getUsername
         );
     }
@@ -315,5 +334,19 @@ class UserRepositoryTest {
 
             return null;
         });
+    }
+
+    /**
+     * Clones the given {@link User} (i.e creates a new {@link User} instance using the same values
+     * as the given).
+     *
+     * @return A new instance of the {@link User}.
+     */
+    private static User cloneUser(final User user) {
+        return new User(
+            user.getUsername(),
+            user.getName(),
+            user.getBirthDate()
+        );
     }
 }


### PR DESCRIPTION
# Summary

This PR fixes a bug in which searching a Book by author or a User by username, when more than one Book with the same author or User with the same username exist in the database, an exception is thrown. It does not references to any card.

# Notes

- The fix is just adding a First to the repositories methods (e.g `findByAuthor` is now called `findFirstByAuthor`).
