### PR TITLE
Rest/query params

### DIFF
--- a/src/main/java/wolox/training/repositories/BookRepository.java
+++ b/src/main/java/wolox/training/repositories/BookRepository.java
@@ -3,6 +3,7 @@ package wolox.training.repositories;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -15,7 +16,7 @@ import wolox.training.utils.Utils;
  * A repository for {@link Book}s.
  */
 @Repository
-public interface BookRepository extends CrudRepository<Book, Long> {
+public interface BookRepository extends CrudRepository<Book, Long>, JpaSpecificationExecutor<Book> {
 
     /**
      * Returns one {@link Book} of the given {@code author}

--- a/src/main/java/wolox/training/repositories/BookSpecification.java
+++ b/src/main/java/wolox/training/repositories/BookSpecification.java
@@ -1,0 +1,95 @@
+package wolox.training.repositories;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import lombok.AllArgsConstructor;
+import org.springframework.data.jpa.domain.Specification;
+import wolox.training.models.Book;
+
+/**
+ * A {@link Specification} for {@link Book}s.
+ */
+@AllArgsConstructor
+public class BookSpecification implements Specification<Book> {
+
+    /**
+     * Filter for genre.
+     */
+    private final String genre;
+    /**
+     * Filter for author.
+     */
+    private final String author;
+    /**
+     * Filter for image.
+     */
+    private final String image;
+    /**
+     * Filter for title.
+     */
+    private final String title;
+    /**
+     * Filter for subtitle.
+     */
+    private final String subtitle;
+    /**
+     * Filter for publisher.
+     */
+    private final String publisher;
+    /**
+     * Filter for year.
+     */
+    private final String year;
+    /**
+     * Filter for pages.
+     */
+    private final Integer pages;
+    /**
+     * Filter for isbn.
+     */
+    private final String isbn;
+
+
+    @Override
+    public Predicate toPredicate(
+        final Root<Book> root,
+        final CriteriaQuery<?> query,
+        final CriteriaBuilder criteriaBuilder) {
+
+        final List<Predicate> predicates = new LinkedList<>();
+        Optional.ofNullable(genre)
+            .map(value -> criteriaBuilder.equal(root.get("genre"), value))
+            .ifPresent(predicates::add);
+        Optional.ofNullable(author)
+            .map(value -> criteriaBuilder.equal(root.get("author"), value))
+            .ifPresent(predicates::add);
+        Optional.ofNullable(image)
+            .map(value -> criteriaBuilder.equal(root.get("image"), value))
+            .ifPresent(predicates::add);
+        Optional.ofNullable(title)
+            .map(value -> criteriaBuilder.equal(root.get("title"), value))
+            .ifPresent(predicates::add);
+        Optional.ofNullable(subtitle)
+            .map(value -> criteriaBuilder.equal(root.get("subtitle"), value))
+            .ifPresent(predicates::add);
+        Optional.ofNullable(publisher)
+            .map(value -> criteriaBuilder.equal(root.get("publisher"), value))
+            .ifPresent(predicates::add);
+        Optional.ofNullable(year)
+            .map(value -> criteriaBuilder.equal(root.get("year"), value))
+            .ifPresent(predicates::add);
+        Optional.ofNullable(pages)
+            .map(value -> criteriaBuilder.equal(root.get("pages"), value))
+            .ifPresent(predicates::add);
+        Optional.ofNullable(isbn)
+            .map(value -> criteriaBuilder.equal(root.get("isbn"), value))
+            .ifPresent(predicates::add);
+
+        return predicates.stream().reduce(criteriaBuilder.and(), criteriaBuilder::and);
+    }
+}

--- a/src/main/java/wolox/training/repositories/UserRepository.java
+++ b/src/main/java/wolox/training/repositories/UserRepository.java
@@ -3,6 +3,7 @@ package wolox.training.repositories;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -13,7 +14,7 @@ import wolox.training.models.User;
  * A repository for {@link User}s.
  */
 @Repository
-public interface UserRepository extends CrudRepository<User, Long> {
+public interface UserRepository extends CrudRepository<User, Long>, JpaSpecificationExecutor<User> {
 
     /**
      * Returns one {@link User} with the given {@code username}

--- a/src/main/java/wolox/training/repositories/UserSpecification.java
+++ b/src/main/java/wolox/training/repositories/UserSpecification.java
@@ -1,0 +1,63 @@
+package wolox.training.repositories;
+
+import java.time.LocalDate;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import lombok.AllArgsConstructor;
+import org.springframework.data.jpa.domain.Specification;
+import wolox.training.models.User;
+
+/**
+ * A {@link Specification} for {@link User}s.
+ */
+@AllArgsConstructor
+public class UserSpecification implements Specification<User> {
+
+    /**
+     * Filter for username.
+     */
+    private final String username;
+    /**
+     * Filter for name.
+     */
+    private final String name;
+    /**
+     * The min. {@link LocalDate} all returned {@link User}s when using this {@link Specification}
+     * will have.
+     */
+    private final LocalDate from;
+    /**
+     * The max. {@link LocalDate} all returned {@link User}s when using this {@link Specification}
+     * will have.
+     */
+    private final LocalDate to;
+
+
+    @Override
+    public Predicate toPredicate(
+        final Root<User> root,
+        final CriteriaQuery<?> query,
+        final CriteriaBuilder criteriaBuilder) {
+
+        final List<Predicate> predicates = new LinkedList<>();
+        Optional.ofNullable(username)
+            .map(value -> criteriaBuilder.equal(root.get("username"), value))
+            .ifPresent(predicates::add);
+        Optional.ofNullable(name)
+            .map(value -> criteriaBuilder.equal(root.get("name"), value))
+            .ifPresent(predicates::add);
+        Optional.ofNullable(from)
+            .map(value -> criteriaBuilder.greaterThanOrEqualTo(root.get("birthDate"), value))
+            .ifPresent(predicates::add);
+        Optional.ofNullable(to)
+            .map(value -> criteriaBuilder.lessThanOrEqualTo(root.get("birthDate"), value))
+            .ifPresent(predicates::add);
+
+        return predicates.stream().reduce(criteriaBuilder.and(), criteriaBuilder::and);
+    }
+}

--- a/src/main/java/wolox/training/web/controllers/BookController.java
+++ b/src/main/java/wolox/training/web/controllers/BookController.java
@@ -17,6 +17,7 @@ import wolox.training.models.Book;
 import wolox.training.repositories.BookRepository;
 import wolox.training.services.open_library.OpenLibraryService;
 import wolox.training.web.dtos.BookCreationRequestDto;
+import wolox.training.web.dtos.BookSpecificationDto;
 
 /**
  * The {@link Book}s REST controller.
@@ -61,8 +62,8 @@ public class BookController {
      * Might be empty.
      */
     @GetMapping
-    public ResponseEntity<Iterable<Book>> getAllBooks() {
-        final var books = bookRepository.findAll();
+    public ResponseEntity<Iterable<Book>> getAllBooks(final BookSpecificationDto dto) {
+        final var books = bookRepository.findAll(dto.getSpecification());
         return ResponseEntity.ok(books);
     }
 

--- a/src/main/java/wolox/training/web/controllers/UserController.java
+++ b/src/main/java/wolox/training/web/controllers/UserController.java
@@ -4,7 +4,6 @@ import java.security.Principal;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.mvc.ControllerLinkBuilder;
@@ -29,6 +28,7 @@ import wolox.training.repositories.UserRepository;
 import wolox.training.web.dtos.ChangePasswordRequestDto;
 import wolox.training.web.dtos.UserCreationRequestDto;
 import wolox.training.web.dtos.UserDownloadDto;
+import wolox.training.web.dtos.UserSpecificationDto;
 
 /**
  * The {@link User}'s REST controller.
@@ -72,8 +72,9 @@ public class UserController {
      * Might be empty.
      */
     @GetMapping
-    public ResponseEntity<Iterable<UserDownloadDto>> getAllUsers() {
-        final var users = StreamSupport.stream(userRepository.findAll().spliterator(), false)
+    public ResponseEntity<Iterable<UserDownloadDto>> getAllUsers(final UserSpecificationDto dto) {
+        final var users = userRepository.findAll(dto.getSpecification())
+            .stream()
             .map(UserDownloadDto::new)
             .collect(Collectors.toList());
 

--- a/src/main/java/wolox/training/web/dtos/BookSpecificationDto.java
+++ b/src/main/java/wolox/training/web/dtos/BookSpecificationDto.java
@@ -1,0 +1,48 @@
+package wolox.training.web.dtos;
+
+import org.springframework.web.bind.annotation.RequestParam;
+import wolox.training.repositories.BookSpecification;
+
+/**
+ * A DTO for {@link BookSpecification}
+ */
+public class BookSpecificationDto extends SpecificationDto<BookSpecification> {
+
+    /**
+     * Constructor
+     *
+     * @param genre The genre for the {@link BookSpecification}.
+     * @param author The author for the {@link BookSpecification}.
+     * @param image The image for the {@link BookSpecification}.
+     * @param title The title for the {@link BookSpecification}.
+     * @param subtitle The subtitle for the {@link BookSpecification}.
+     * @param publisher The publisher for the {@link BookSpecification}.
+     * @param year The year for the {@link BookSpecification}.
+     * @param pages The pages for the {@link BookSpecification}.
+     * @param isbn The isbn for the {@link BookSpecification}.
+     */
+    public BookSpecificationDto(
+        @RequestParam(name = "genre", required = false) final String genre,
+        @RequestParam(name = "author", required = false) final String author,
+        @RequestParam(name = "image", required = false) final String image,
+        @RequestParam(name = "title", required = false) final String title,
+        @RequestParam(name = "subtitle", required = false) final String subtitle,
+        @RequestParam(name = "publisher", required = false) final String publisher,
+        @RequestParam(name = "year", required = false) final String year,
+        @RequestParam(name = "pages", required = false) final Integer pages,
+        @RequestParam(name = "isbn", required = false) final String isbn) {
+        super(
+            new BookSpecification(
+                genre,
+                author,
+                image,
+                title,
+                subtitle,
+                publisher,
+                year,
+                pages,
+                isbn
+            )
+        );
+    }
+}

--- a/src/main/java/wolox/training/web/dtos/SpecificationDto.java
+++ b/src/main/java/wolox/training/web/dtos/SpecificationDto.java
@@ -1,0 +1,25 @@
+package wolox.training.web.dtos;
+
+import lombok.Getter;
+import org.springframework.data.jpa.domain.Specification;
+
+/**
+ * A generic DTO for {@link Specification}.
+ */
+@Getter
+public class SpecificationDto<S extends Specification<?>> {
+
+    /**
+     * The {@link Specification} being wrapped.
+     */
+    private final S specification;
+
+    /**
+     * Constructor.
+     *
+     * @param specification The {@link Specification} being wrapped.
+     */
+    public SpecificationDto(final S specification) {
+        this.specification = specification;
+    }
+}

--- a/src/main/java/wolox/training/web/dtos/UserSpecificationDto.java
+++ b/src/main/java/wolox/training/web/dtos/UserSpecificationDto.java
@@ -1,0 +1,31 @@
+package wolox.training.web.dtos;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.web.bind.annotation.RequestParam;
+import wolox.training.repositories.UserSpecification;
+
+/**
+ * A DTO for {@link UserSpecification}
+ */
+@Getter
+public class UserSpecificationDto extends SpecificationDto<UserSpecification> {
+
+    /**
+     * Constructor.
+     *
+     * @param username The username for the {@link UserSpecification}.
+     * @param name The name for the {@link UserSpecification}.
+     * @param from The from for the {@link UserSpecification}.
+     * @param to The to for the {@link UserSpecification}.
+     */
+    public UserSpecificationDto(
+        @RequestParam(name = "username", required = false) final String username,
+        @RequestParam(name = "name", required = false) final String name,
+        @RequestParam(name = "from", required = false) @DateTimeFormat(iso = ISO.DATE) final LocalDate from,
+        @RequestParam(name = "to", required = false) @DateTimeFormat(iso = ISO.DATE) final LocalDate to) {
+        super(new UserSpecification(username, name, from, to));
+    }
+}

--- a/src/test/java/wolox/training/web/BookControllerTest.java
+++ b/src/test/java/wolox/training/web/BookControllerTest.java
@@ -42,6 +42,7 @@ import org.springframework.test.web.servlet.RequestBuilder;
 import wolox.training.models.Book;
 import wolox.training.repositories.BlacklistedJwtTokenRepository;
 import wolox.training.repositories.BookRepository;
+import wolox.training.repositories.BookSpecification;
 import wolox.training.repositories.UserRepository;
 import wolox.training.services.authentication.JwtTokenService;
 import wolox.training.services.open_library.OpenLibraryService;
@@ -51,6 +52,7 @@ import wolox.training.web.JwtExtension.AuthenticatedWithJwt;
 import wolox.training.web.JwtExtension.ValidJwt;
 import wolox.training.web.controllers.BookController;
 import wolox.training.web.dtos.BookCreationRequestDto;
+import wolox.training.web.dtos.BookSpecificationDto;
 
 /**
  * Testing for the {@link BookController}.
@@ -138,7 +140,8 @@ class BookControllerTest {
 
     /**
      * Tests the API response when requesting all {@link Book}s (i.e using the controller method
-     * {@link BookController#getAllBooks()}), and none is returned by the {@link BookRepository}.
+     * {@link BookController#getAllBooks(BookSpecificationDto)}), and none is returned by the {@link
+     * BookRepository}.
      *
      * @param jwt An injected JWT to be sent in order to authenticate with the server
      * @throws Exception if {@link MockMvc#perform(RequestBuilder)} throws it.
@@ -154,13 +157,13 @@ class BookControllerTest {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(jsonPath("$", hasSize(0)))
         ;
-        verify(bookRepository, only()).findAll();
+        verify(bookRepository, only()).findAll(any(BookSpecification.class));
     }
 
     /**
      * Tests the API response when requesting all {@link Book}s (i.e using the controller method
-     * {@link BookController#getAllBooks()}), and a non-empty {@link Iterable} is returned by the
-     * {@link BookRepository}.
+     * {@link BookController#getAllBooks(BookSpecificationDto)}), and a non-empty {@link Iterable}
+     * is returned by the {@link BookRepository}.
      *
      * @param jwt An injected JWT to be sent in order to authenticate with the server
      * @throws Exception if {@link MockMvc#perform(RequestBuilder)} throws it.
@@ -172,14 +175,16 @@ class BookControllerTest {
         final var maxListSize = 10;
         final var mockedList = TestHelper.mockBookList(maxListSize);
         mockedList.forEach(TestHelper::addId);
-        when(bookRepository.findAll()).thenReturn(mockedList);
+        // Mock with "any" as we are only testing without filtering
+        when(bookRepository.findAll(any(BookSpecification.class)))
+            .thenReturn(mockedList);
         mockMvc.perform(withJwt(get(BOOKS_PATH).accept(MediaType.APPLICATION_JSON_UTF8_VALUE), jwt))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(jsonPath("$", hasSize(mockedList.size())))
             .andExpect(bookListJsonResultMatcher(mockedList))
         ;
-        verify(bookRepository, only()).findAll();
+        verify(bookRepository, only()).findAll(any(BookSpecification.class));
     }
 
 


### PR DESCRIPTION
# Summary

This PR adds dynamic filtering, which allows optional filtering, according to the trello card: [https://trello.com/c/NeAzjQFS](https://trello.com/c/NeAzjQFS).

# Notes

This feature is implemented using `Specification`. More info in these articles:

- https://www.baeldung.com/rest-api-search-language-spring-data-specifications
- https://dzone.com/articles/using-spring-data-jpa-specification
- https://spring.io/blog/2011/04/26/advanced-spring-data-jpa-specifications-and-querydsl/


# Trello Card

https://trello.com/c/NeAzjQFS
