### PR TITLE
repositories/paging-sorting

### DIFF
--- a/src/main/java/wolox/training/web/controllers/BookController.java
+++ b/src/main/java/wolox/training/web/controllers/BookController.java
@@ -2,6 +2,7 @@ package wolox.training.web.controllers;
 
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -62,8 +63,10 @@ public class BookController {
      * Might be empty.
      */
     @GetMapping
-    public ResponseEntity<Iterable<Book>> getAllBooks(final BookSpecificationDto dto) {
-        final var books = bookRepository.findAll(dto.getSpecification());
+    public ResponseEntity<Iterable<Book>> getAllBooks(
+        final BookSpecificationDto dto,
+        final Pageable pageable) {
+        final var books = bookRepository.findAll(dto.getSpecification(), pageable).getContent();
         return ResponseEntity.ok(books);
     }
 

--- a/src/main/java/wolox/training/web/controllers/UserController.java
+++ b/src/main/java/wolox/training/web/controllers/UserController.java
@@ -6,6 +6,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -72,12 +73,13 @@ public class UserController {
      * Might be empty.
      */
     @GetMapping
-    public ResponseEntity<Iterable<UserDownloadDto>> getAllUsers(final UserSpecificationDto dto) {
-        final var users = userRepository.findAll(dto.getSpecification())
+    public ResponseEntity<Iterable<UserDownloadDto>> getAllUsers(
+        final UserSpecificationDto dto,
+        final Pageable pageable) {
+        final var users = userRepository.findAll(dto.getSpecification(), pageable)
             .stream()
             .map(UserDownloadDto::new)
             .collect(Collectors.toList());
-
         return ResponseEntity.ok(users);
     }
 


### PR DESCRIPTION
# Summary

This PR adds paging and sorting, according to the trello card: [https://trello.com/c/AR9fGuG4](https://trello.com/c/AR9fGuG4).

# Notes

The `JpaSpecificationExecutor` interface being extended in both repositories in #22 added methods to those repositories that receive the `Pageable` object.


# Trello Card

https://trello.com/c/AR9fGuG4
