### PR TITLE
bug/books-security

### DIFF
--- a/src/main/java/wolox/training/web/security/WebSecurityConfig.java
+++ b/src/main/java/wolox/training/web/security/WebSecurityConfig.java
@@ -70,7 +70,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
             .mvcMatchers(HttpMethod.POST, "/api/tokens").permitAll()
             .mvcMatchers(HttpMethod.POST, "/api/users").permitAll()
             .mvcMatchers(HttpMethod.PUT, "/api/users/{userId:\\d+}/password").permitAll()
-            .mvcMatchers(HttpMethod.POST, "/api/books/").permitAll()
+            .mvcMatchers(HttpMethod.POST, "/api/books").permitAll()
             .anyRequest().authenticated()
             .and()
             .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
# Summary

This PR fixes the `mvcMatcher` that allows anonymous access to the `Book` creation resource. It does not correspond to any trello card.