### PR TITLE
Bug/password test

### DIFF
--- a/src/test/java/wolox/training/models/UserTest.java
+++ b/src/test/java/wolox/training/models/UserTest.java
@@ -223,7 +223,7 @@ class UserTest {
     void testMatchPasswordWhenNotSet() {
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> TestHelper.mockUser().passwordMatches(Mockito.anyString()),
+            () -> TestHelper.mockUser().passwordMatches(ValuesGenerator.validPassword()),
             "Matching a password for a User without a password is being allowed"
         );
     }


### PR DESCRIPTION
This PR fixes the `UserTest#testMatchPasswordWhenNotSet` method, as `Mockito#anyString` makes the test fail in some cases. It is replaced by a valid password generated by the utils library.